### PR TITLE
feat(core): add stdio e2e and update config, server, docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,23 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${PUBLIC_RELEASE_BOT_TOKEN}" >> .npmrc
 
       - name: Release
+        id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
         run: npx semantic-release
+      
+      - name: Trigger Beta Update Workflow
+        if: github.ref == 'refs/heads/main' && steps.semantic-release.outcome == 'success'
+        run: |
+          # Extract the tag from the semantic-release output
+          NEW_TAG=$(git describe --tags --abbrev=0)
+          
+          echo "Triggering update-beta-after-release workflow for tag: $NEW_TAG"
+          
+          # Trigger repository_dispatch event
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d "{\"event_type\":\"release_created\",\"client_payload\":{\"tag_name\":\"$NEW_TAG\"}}"

--- a/.github/workflows/update-beta-after-release.yml
+++ b/.github/workflows/update-beta-after-release.yml
@@ -1,0 +1,128 @@
+name: 🔄 Update Beta After Release
+
+on:
+  repository_dispatch:
+    types: [release_created]
+  push:
+    tags:
+      # This will only match full semantic version tags (no beta tags)
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  update-beta:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
+      
+      - name: Set tag name based on trigger type
+        id: set-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            # For repository_dispatch events, get tag from payload
+            TAG_NAME="${{ github.event.client_payload.tag_name }}"
+            echo "Using tag from repository_dispatch: $TAG_NAME"
+          else
+            # For push events, get tag from ref_name
+            TAG_NAME="${{ github.ref_name }}"
+            echo "Using tag from push event: $TAG_NAME"
+          fi
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+      
+      - name: Verify tag is from main branch
+        id: verify-branch
+        run: |
+          # Get the commit that this tag points to
+          TAG_COMMIT=$(git rev-parse ${{ steps.set-tag.outputs.tag_name }})
+          
+          # Check if this commit is on main branch
+          if git branch -r --contains $TAG_COMMIT | grep "origin/main"; then
+            echo "Tag is from main branch, proceeding"
+            echo "is_main_branch=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Tag ${{ steps.set-tag.outputs.tag_name }} was not created on main branch. Exiting workflow."
+            exit 78 # Neutral exit code that GitHub treats as cancelled rather than failed
+          fi
+      
+      - name: Setup Git
+        run: |
+          git config --global user.name "gr0wth-b0t"
+          git config --global user.email "gsBot@growthspace.com"
+      
+      - name: Create merge branch and resolve conflicts
+        id: create-merge
+        run: |
+          TODAY=$(date '+%Y-%m-%d')
+          TAG_NAME="${{ steps.set-tag.outputs.tag_name }}"
+          TEMP_BRANCH="temp-merge-$TODAY"
+          
+          # Create a temporary branch from beta
+          git checkout beta
+          
+          # Fetch main branch from origin
+          git fetch origin main
+          
+          # Create a temporary branch from beta
+          git checkout -b $TEMP_BRANCH
+          
+          # Attempt to merge origin/main instead of main
+          if git merge origin/main -m "chore: merge main into beta after release $TAG_NAME"; then
+            echo "Merged successfully without conflicts"
+          else
+            echo "Conflicts detected, resolving automatically..."
+            
+            # For conflicts in package files, take --ours (beta) version
+            if git diff --name-only --diff-filter=U | grep -E 'package(-lock)?\.json'; then
+              git checkout --ours package.json package-lock.json
+              git add package.json package-lock.json
+              git commit --no-verify -m "chore: resolve version conflicts after merging $TAG_NAME"
+              echo "resolved=true" >> $GITHUB_OUTPUT
+            else
+              # If we have other conflicts, abort and create PR for manual resolution
+              git merge --abort
+              echo "Non-version conflicts detected, creating PR for manual resolution"
+              git push origin $TEMP_BRANCH
+              echo "resolved=false" >> $GITHUB_OUTPUT
+              echo "::warning::Non-version conflicts were found that require manual resolution"
+            fi
+          fi
+          
+          # Push the branch
+          git push origin $TEMP_BRANCH
+          
+          echo "branch_name=$TEMP_BRANCH" >> $GITHUB_OUTPUT
+        env:
+          HUSKY: '0'
+      
+      - name: Create PR from temp branch to beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
+          TEMP_BRANCH: ${{ steps.create-merge.outputs.branch_name }}
+          CONFLICTS_RESOLVED: ${{ steps.create-merge.outputs.resolved }}
+          TAG_NAME: ${{ steps.set-tag.outputs.tag_name }}
+        run: |
+          TODAY=$(date '+%Y-%m-%d')
+          
+          # Create PR title based on conflict resolution status
+          PR_TITLE="[RELEASE][REVERSE][AUTO] 🥶 Release Candidate for beta $TODAY"
+          
+          # Create PR body
+          PR_BODY="This PR was automatically created to update beta with the latest release from main."
+          
+          if [[ "$CONFLICTS_RESOLVED" == "true" ]]; then
+            PR_BODY="$PR_BODY\n\nVersion conflicts in package.json and package-lock.json were automatically resolved by keeping the beta version."
+          elif [[ "$CONFLICTS_RESOLVED" == "false" ]]; then
+            PR_BODY="$PR_BODY\n\n**Action required:** This PR contains conflicts that need manual resolution."
+          fi
+          
+          # Create PR using GitHub CLI
+          gh pr create \
+            --base beta \
+            --head $TEMP_BRANCH \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY"
+
+

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ npm run start:prod -- --config /path/to/config.json
 
 # With remote config URL
 npm run start:prod -- --config https://example.com/config.json
+
+# Stdio server mode (serve one downstream over stdio)
+# Select the downstream with --stdio-target when multiple are configured
+npm run build
+npm run start:stdio -- --stdio-target github-allow
 ```
 
 ### Minimal Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,36 @@ This project supports a v2 JSON configuration format. Configuration can be provi
 - `addr` (required): Bind address (e.g., `:8083`)
 - `name` (required): Server identity for MCP handshake
 - `version` (required): Server version for MCP handshake
-- `type` (optional): `sse` (default) or `streamable-http`
+- `type` (optional): `sse` (default), `streamable-http`, or `stdio`
+  - `stdio`: Serve exactly one downstream MCP server over stdio. Select target via CLI `--stdio-target <name>` or configure only one `mcpServers` entry.
+
+#### Stdio server mode example
+
+```json
+{
+  "mcpProxy": {
+    "name": "MCP Proxy",
+    "version": "1.0.0",
+    "type": "stdio"
+  },
+  "mcpServers": {
+    "github-allow": {
+      "transportType": "streamable-http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" },
+      "options": {
+        "toolFilter": { "mode": "allow", "list": ["list_issues", "search_repositories"] }
+      }
+    }
+  }
+}
+```
+
+Run:
+
+```bash
+node dist/main.js --config ./config.json --stdio-target github-allow
+```
 - `options` (optional): Defaults inherited by `mcpServers.*.options` (can be overridden per server)
 
 ### mcpServers

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "start:stdio": "node dist/main.js --config config.json",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "prepare": "husky",
     "commit": "cz",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,4 @@
-export type MCPServerType = 'sse' | 'streamable-http';
+export type MCPServerType = 'sse' | 'streamable-http' | 'stdio';
 
 export type MCPClientType = 'stdio' | 'sse' | 'streamable-http';
 

--- a/src/mcp/mcp-server.service.ts
+++ b/src/mcp/mcp-server.service.ts
@@ -16,7 +16,7 @@ export interface IMCPServerInstance {
   server: Server;
   clientWrapper: MCPClientWrapper;
   transports: Map<string, SSEServerTransport | StreamableHTTPServerTransport>;
-  serverType: 'sse' | 'streamable-http';
+  serverType: 'sse' | 'streamable-http' | 'stdio';
 }
 export type MCPServerInstance = IMCPServerInstance;
 

--- a/test/mcp.stdio.e2e-spec.ts
+++ b/test/mcp.stdio.e2e-spec.ts
@@ -1,0 +1,81 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+describe('MCP Proxy Stdio Mode (e2e)', () => {
+  const skip = !process.env.GITHUB_TOKEN;
+  const maybeIt = skip ? it.skip : it;
+  let tmpConfigPath: string;
+
+  beforeAll(async () => {
+    if (skip) return;
+    // Prepare a temp config with stdio mode
+    const cfgSrcPath = path.join(__dirname, '..', 'config.json');
+    const cfg = JSON.parse(fs.readFileSync(cfgSrcPath, 'utf-8'));
+
+    // Set stdio mode
+    cfg.mcpProxy.type = 'stdio';
+
+    // Restrict to only github-allow with allow-list
+    const originalServers = (cfg.mcpServers ?? {}) as Record<string, any>;
+    const mcpServers: Record<string, any> = {};
+    if (originalServers.github) {
+      const allowGithub = JSON.parse(JSON.stringify(originalServers.github));
+      allowGithub.options = allowGithub.options || {};
+      allowGithub.options.toolFilter = {
+        mode: 'allow',
+        list: [ 'list_issues', 'search_repositories' ]
+      };
+      mcpServers['github-allow'] = allowGithub;
+    }
+    cfg.mcpServers = mcpServers;
+
+    tmpConfigPath = path.join(__dirname, 'config.stdio.e2e.json');
+    fs.writeFileSync(tmpConfigPath, JSON.stringify(cfg, null, 2));
+  }, 60000);
+
+  afterAll(async () => {
+    if (skip) return;
+    try {
+      fs.unlinkSync(tmpConfigPath);
+    } catch {}
+  });
+
+  maybeIt('should expose only allow-listed tools via stdio', async () => {
+    // Create stdio client transport - it will spawn the process via ts-node
+    const mainTsPath = path.join(__dirname, '..', 'src', 'main.ts');
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: [ '-r', 'ts-node/register', mainTsPath, '--config', tmpConfigPath, '--stdio-target', 'github-allow' ],
+      env: { ...process.env }
+    });
+
+    const mcpClient = new Client({ name: 'e2e-stdio', version: '0.0.1' });
+    await mcpClient.connect(transport);
+
+    // Wait a bit for initialization
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Test listTools
+    const tools = await mcpClient.listTools({});
+    const toolNames = tools.tools.map((t) => t.name).sort();
+
+    expect(toolNames).toEqual([ 'list_issues', 'search_repositories' ]);
+
+    // Optionally test calling a tool
+    if (toolNames.includes('search_repositories')) {
+      const result = await mcpClient.callTool({
+        name: 'search_repositories',
+        arguments: { query: 'language:typescript stars:>100' }
+      });
+      expect(result).toBeDefined();
+      expect(result.content).toBeDefined();
+    }
+
+    await mcpClient.close();
+  }, 60000);
+});
+


### PR DESCRIPTION
## Description

- Add stdio server mode with `--stdio-target`
- Enforce single downstream in stdio; clear error if ambiguous
- Add E2E tests for stdio mode
- Automate updating `beta` branch after releases
- Update docs and configuration
- No breaking changes for SSE/HTTP users

## Related Issues

Closes #43
Closes #44

## Checklist

- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)