### PR TITLE
fix(jest): make sure jest extension runs the e2e tests correctly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,18 +25,21 @@
   },
   "gitlens.ai.generateCommitMessage.customInstructions": ".vscode/commit-message-instructions.md",
   "peacock.color": "#750687",
+  "jest.useJest30": true,
   "jest.virtualFolders": [
     {
       "name": "unit-tests",
-      "path": "src"
+      "rootPath": "src"
     },
     {
       "name": "e2e-tests",
-      "path": "e2e"
-    },
+      "jestCommandLine": "npm test -- --config ./e2e/jest-e2e.config.ts --runInBand",
+      "rootPath": "e2e"
+    }
   ],
   "jest.runMode": {
     "type": "on-save",
+    // coverage shows only one test type at a time
     "coverage": false,
     "runAllTestsOnStartup": true
   },


### PR DESCRIPTION
## Description
the jest extension showed both unit and e2e but ran unit tests for both

## Related Issues
<!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->
<!-- Example: Closes #42 -->



## Checklist
- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)
