### PR TITLE
fix(release): remove ref to ticket in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,6 @@
 
 ## Related Issues
 <!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->
-<!-- Example: Closes #42 -->
-
-
 
 ## Checklist
 - Code follows project style guidelines


### PR DESCRIPTION
## Description
ref to ticket 42 in html comment meant semantic release tried to tag the issue with a comment and failed. removing it from the template

## Related Issues
<!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->



## Checklist
- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)
