### PR TITLE
feat(docker): add Docker config and docs; fix build entrypoint; expose 8084

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY package*.json ./
 RUN npm ci
 
 # Copy build configuration and sources
-COPY tsconfig.json nest-cli.json ./
+COPY tsconfig.json tsconfig.build.json nest-cli.json ./
 COPY src ./src
 COPY config.json ./config.json
 
@@ -27,11 +27,12 @@ RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund
 # Bring in the compiled app and default config
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/config.json ./config.json
+COPY config.docker.json ./config.docker.json
 
-# Default port (can be overridden by config.json)
-EXPOSE 8083
+# Default port (matches config.json)
+EXPOSE 8084
 
-# Default command uses the bundled config file; override with docker run args if needed
-CMD ["node", "dist/src/main.js", "--config", "/app/config.json"]
+# Default command uses the docker config; override with docker run args if needed
+CMD ["node", "dist/main.js", "--config", "/app/config.docker.json"]
 
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ An MCP proxy that aggregates multiple MCP servers behind a single HTTP entrypoin
 - [Configuration](docs/configuration.md) - Configuration reference and examples
 - [Usage](docs/usage.md) - CLI options, endpoints, authentication, and tool filtering
 - [PII Redaction](docs/redaction.md) - Redaction setup and configuration
-- [Deployment](docs/deployment.md) - Docker and production deployment
+- [Deployment](docs/deployment.md) - Production deployment
+- [Docker Usage](docs/docker.md) - Build, run, and configure the Docker image
 
 ## Quick Start
 

--- a/config.docker.json
+++ b/config.docker.json
@@ -1,0 +1,16 @@
+{
+  "mcpProxy": {
+    "baseURL": "http://0.0.0.0:8084",
+    "addr": ":8084",
+    "name": "MCP Proxy with PII Redaction (Docker)",
+    "version": "1.0.0",
+    "type": "sse",
+    "options": {
+      "panicIfInvalid": false,
+      "logEnabled": true
+    }
+  },
+  "mcpServers": {}
+}
+
+

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,104 @@
+# Docker Usage
+
+This guide shows how to run the proxy in Docker, configure ports, and override the configuration for your own MCP servers.
+
+## Image
+
+- Registry: `ghcr.io`
+- Image: `ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor`
+- Tags: `latest` (main), `beta` (beta branch), and semantic versions
+
+## Default behavior
+
+- The container listens on port `8084` by default (configurable via the config file).
+- The container starts with: `node dist/main.js --config /app/config.docker.json`.
+- Health endpoint: `GET /` returns `{ "status": "ok" }`.
+
+Run it:
+
+```bash
+docker run -p 8084:8084 ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor:latest
+```
+
+## Override the configuration
+
+You can provide your own config to define MCP servers, authentication, and transport type.
+
+### Option 1 — Bind-mount over the default path (simple)
+
+Mount your file as `/app/config.docker.json`.
+
+```bash
+docker run \
+  -p 8084:8084 \
+  -v "$(pwd)/myconfig.json:/app/config.docker.json:ro" \
+  -e GITHUB_TOKEN=ghp_xxx_if_used_in_headers \
+  ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor:latest
+```
+
+### Option 2 — Use a different path or a URL
+
+Override the container command to pass a different file path or a URL.
+
+```bash
+# Using a different file path inside the container
+docker run \
+  -p 8084:8084 \
+  -v "$(pwd)/myconfig.json:/app/myconfig.json:ro" \
+  ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor:latest \
+  node dist/main.js --config /app/myconfig.json
+
+# Loading from a URL
+docker run \
+  -p 8084:8084 \
+  ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor:latest \
+  node dist/main.js --config https://example.com/myconfig.json
+
+# If the URL uses a self-signed certificate, add --insecure
+```
+
+### Option 3 — Docker Compose
+
+```yaml
+services:
+  mcp-proxy:
+    image: ghcr.io/growthspace-engineering/gs-mcp-proxy-pii-redactor:latest
+    ports:
+      - "8084:8084"
+    volumes:
+      - ./myconfig.json:/app/config.docker.json:ro
+    environment:
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+    # Or use a custom config path or URL by overriding the command:
+    # command: ["node", "dist/main.js", "--config", "/app/myconfig.json"]
+```
+
+## Notes
+
+- Environment variables inside config headers (e.g., `${GITHUB_TOKEN}`) are expanded inside the container. Pass them with `-e VAR=value` or via Compose `environment:`.
+- The listener is set by `mcpProxy.addr` in your config (default `:8084`). If you change it, update your `-p` mapping accordingly.
+- Supported server modes: set `mcpProxy.type` to `sse`, `streamable-http`, or `stdio`.
+
+## Minimal example config
+
+```json
+{
+  "mcpProxy": {
+    "baseURL": "http://0.0.0.0:8084",
+    "addr": ":8084",
+    "name": "MCP Proxy",
+    "version": "1.0.0",
+    "type": "sse",
+    "options": { "logEnabled": true }
+  },
+  "mcpServers": {
+    "github": {
+      "transportType": "streamable-http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" }
+    }
+  }
+}
+```
+
+


### PR DESCRIPTION
## Description

- Docker
  - Added `config.docker.json` and set container default command to `--config /app/config.docker.json`.
  - Expose port `8084` to match config and runtime.
  - Fixed build by copying `tsconfig.build.json` and corrected entrypoint to `dist/main.js`.

- Documentation
  - Added `docs/docker.md` with usage instructions:
    - Run image on port 8084
    - Override config by bind-mount, custom path, or URL
    - Pass env vars for header interpolation
    - Example Docker Compose
    - Minimal example config
  - Linked the Docker guide from `README.md`.

Why:
- Resolve build failure in multi-arch pipeline due to missing `tsconfig.build.json` and incorrect entrypoint path.
- Ensure container listens on the configured port (8084).
- Provide clear guidance for running and configuring the image.

Local verification:
- Built and ran the image locally.
- Verified health endpoint on port 8084 returns: {"status":"ok"}.

## Related Issues

Refs #26, Refs #16

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No new warnings generated
- [x] Tests pass locally (`npm test`)
- [x] E2E tests pass if applicable (`npm run test:e2e`)