### PR TITLE
ci(release): enable dual publishing to npm and GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,19 +152,24 @@ jobs:
           project-name-prefix: gs-mcp-proxy-pii-redactor-${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔧 Configure npm for GitHub Packages
+      - name: 🔧 Configure npm for dual registry publishing
         env:
           PUBLIC_RELEASE_BOT_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # Configure GitHub Packages authentication
           echo "@growthspace-engineering:registry=https://npm.pkg.github.com" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=${PUBLIC_RELEASE_BOT_TOKEN}" >> .npmrc
+          
+          # Configure public npm registry authentication
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
 
       - name: 🚀 Semantic Release
         id: semrel
         uses: cycjimmy/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # decide the channel tag (beta vs latest)
       - name: 🔧 Decide Docker channel tag

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,9 +25,16 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true,
+        "pkgRoot": "."
+      }
+    ],
+    [
       "@semantic-release/github",
       {
-        "successComment": "This PR is included in version ${nextRelease.version} 🎉\n\nThe release is available on:\n- [GitHub Releases](https://github.com/growthspace-engineering/gs-mcp-proxy-pii-redactor/releases/tag/${nextRelease.gitTag})\n- [npm package](https://www.npmjs.com/package/@growthspace-engineering/gs-mcp-proxy-pii-redactor/v/${nextRelease.version})",
+        "successComment": "This PR is included in version ${nextRelease.version} 🎉\n\nThe release is available on:\n- [GitHub Releases](https://github.com/growthspace-engineering/gs-mcp-proxy-pii-redactor/releases/tag/${nextRelease.gitTag})\n- [npm package](https://www.npmjs.com/package/@growthspace-engineering/gs-mcp-proxy-pii-redactor/v/${nextRelease.version})\n- [GitHub Packages](https://github.com/growthspace-engineering/gs-mcp-proxy-pii-redactor/packages)",
         "releasedLabels": false,
         "assets": []
       }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "middleware"
   ],
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
     "access": "public"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description
- Configure GitHub Actions to authenticate with both registries
- Add separate @semantic-release/npm plugin for public npm publishing
- Remove registry override in package.json to use default npm registry
- Update success comment to include both npm and GitHub Packages links

This allows the package to be published to both the public npm registry and GitHub Packages simultaneously during the release process.

## Related Issues
<!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->

## Checklist
- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)
