### PR TITLE
feat(groups): add MCP server groups feature

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,11 @@
       "logEnabled": true
     }
   },
+  "groups": {
+    "frontend-engineer": [
+      "proxied-github"
+    ]
+  },
   "mcpServers": {
     "github": {
       "transportType": "streamable-http",

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -29,7 +29,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (fs.readFileSync as jest.Mock).mockReturnValue(
@@ -48,7 +49,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (fs.readFileSync as jest.Mock).mockReturnValue(
@@ -99,7 +101,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (axios.get as jest.Mock).mockResolvedValue({ data: mockConfig });
@@ -119,7 +122,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (axios.get as jest.Mock).mockResolvedValue({ data: mockConfig });
@@ -139,7 +143,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (axios.get as jest.Mock).mockResolvedValue({ data: mockConfig });
@@ -462,7 +467,8 @@ describe('ConfigService', () => {
           type: 'sse' as const,
           options: {}
         },
-        mcpServers: {}
+        mcpServers: {},
+        groups: {}
       };
 
       (fs.readFileSync as jest.Mock).mockReturnValue(

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,11 +49,6 @@ export interface IMCPClientConfigV2 {
 }
 export type MCPClientConfigV2 = IMCPClientConfigV2;
 
-export interface IConfig {
-  mcpProxy: MCPProxyConfigV2;
-  mcpServers: Record<string, MCPClientConfigV2>;
-}
-export type Config = IConfig;
 
 export interface IFullConfig {
   // Deprecated V1
@@ -62,6 +57,14 @@ export interface IFullConfig {
   clients?: any;
   mcpProxy?: MCPProxyConfigV2;
   mcpServers?: Record<string, MCPClientConfigV2>;
+  groups?: Record<string, string[]>;
 }
 export type FullConfig = IFullConfig;
+
+export interface IConfig {
+  mcpProxy: MCPProxyConfigV2;
+  mcpServers: Record<string, MCPClientConfigV2>;
+  groups?: Record<string, string[]>;
+}
+export type Config = IConfig;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,8 @@ async function bootstrap() {
     .option('-h, --help', 'print help and exit', false)
     .option('--init', 'initialize a default config in the user directory and exit', false)
     .option('--init-dest <dir>', 'destination directory for --init (overrides default)')
-    .option('--stdio-target <name>', 'target downstream server name when running in stdio mode');
+    .option('--stdio-target <name>', 'target downstream server name when running in stdio mode')
+    .option('--group <name>', 'group name to filter MCP servers (only servers in this group will expose tools)');
 
   program.parse(process.argv);
   const options = program.opts();
@@ -91,6 +92,13 @@ async function bootstrap() {
   try {
     await configService.load(options.config, options.insecure);
     logger.log('Configuration loaded successfully');
+
+    // Set the active group if provided via CLI flag
+    const groupName = options.group as string | undefined;
+    if (groupName) {
+      configService.setActiveGroup(groupName);
+      logger.log(`Active group set to: ${ groupName }`);
+    }
   } catch (error) {
     logger.error(`Failed to load config: ${ error }`);
     process.exit(1);

--- a/src/mcp/mcp-client-wrapper.ts
+++ b/src/mcp/mcp-client-wrapper.ts
@@ -33,14 +33,17 @@ export class MCPClientWrapper {
   private toolsCache: { data: any[]; expiresAt: number } | null = null;
   private promptsCache: { data: any[]; expiresAt: number } | null = null;
   private resourcesCache: { data: any[]; expiresAt: number } | null = null;
+  private isInGroup: boolean;
 
   constructor(
     name: string,
     config: MCPClientConfigV2,
-    private redactionService: RedactionService
+    private redactionService: RedactionService,
+    isInGroup = true
   ) {
     this.name = name;
     this.config = config;
+    this.isInGroup = isInGroup;
   }
 
   async initialize(): Promise<void> {
@@ -222,6 +225,14 @@ export class MCPClientWrapper {
       throw new Error('Client not initialized');
     }
 
+    // If server is not in the active group, return empty tool list
+    if (!this.isInGroup) {
+      this.logger.log(
+        `<${ this.name }> Server not in active group, returning empty tool list`
+      );
+      return [];
+    }
+
     if (this.toolsCache && this.toolsCache.expiresAt > Date.now()) {
       return this.toolsCache.data;
     }
@@ -247,6 +258,14 @@ export class MCPClientWrapper {
       throw new Error('Client not initialized');
     }
 
+    // If server is not in the active group, return empty prompt list
+    if (!this.isInGroup) {
+      this.logger.log(
+        `<${ this.name }> Server not in active group, returning empty prompt list`
+      );
+      return [];
+    }
+
     try {
       if (this.promptsCache && this.promptsCache.expiresAt > Date.now()) {
         return this.promptsCache.data;
@@ -269,6 +288,14 @@ export class MCPClientWrapper {
   async listResources(): Promise<any[]> {
     if (!this.client) {
       throw new Error('Client not initialized');
+    }
+
+    // If server is not in the active group, return empty resource list
+    if (!this.isInGroup) {
+      this.logger.log(
+        `<${ this.name }> Server not in active group, returning empty resource list`
+      );
+      return [];
     }
 
     try {

--- a/src/mcp/mcp-server.service.spec.ts
+++ b/src/mcp/mcp-server.service.spec.ts
@@ -42,7 +42,8 @@ describe('MCPServerService', () => {
           panicIfInvalid: true
         }
       }
-    }
+    },
+    groups: {}
   };
 
   beforeEach(async () => {
@@ -68,7 +69,8 @@ describe('MCPServerService', () => {
         {
           provide: ConfigService,
           useValue: {
-            getConfig: jest.fn().mockReturnValue(mockConfig)
+            getConfig: jest.fn().mockReturnValue(mockConfig),
+            isServerInActiveGroup: jest.fn().mockReturnValue(true)
           }
         },
         {

--- a/src/mcp/mcp-server.service.ts
+++ b/src/mcp/mcp-server.service.ts
@@ -54,7 +54,13 @@ export class MCPServerService implements OnModuleInit, OnModuleDestroy {
       try {
         this.logger.log(`<${ name }> Initializing client...`);
 
-        const clientWrapper = new MCPClientWrapper(name, clientConfig, this.redactionService);
+        const isInGroup = this.configService.isServerInActiveGroup(name);
+        const clientWrapper = new MCPClientWrapper(
+          name,
+          clientConfig,
+          this.redactionService,
+          isInGroup
+        );
         await clientWrapper.initialize();
 
         const server = await clientWrapper.getServer();


### PR DESCRIPTION
## Description
- Add groups configuration to filter MCP servers by group membership
- Add --group CLI flag to specify active group
- Filter tools, prompts, and resources for servers not in active group
- Servers not in group still initialize but expose empty tool/prompt/resource lists
- Non-existent groups are treated as if no group was specified (backward compatible)
- Update tests to include groups property and mock isServerInActiveGroup method

## Related Issues
<!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->

## Checklist
- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)
