### PR TITLE
fix(mcp): implement lazy initialization for Codex CLI stdio compatibility

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -23,6 +23,23 @@
         "--stdio-target",
         "github"
       ]
+    },
+    "dogfooding-proxy-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "ts-node",
+        "--require",
+        "tsconfig-paths/register",
+        "src/main.ts",
+        "--config",
+        "./.cursor/config.json",
+        "--stdio-target",
+        "github",
+        "--group",
+        "frontend-engineer"
+      ],
+      "workingDirectory": "."
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 config.json
 .env*
 
+# Codex local config (contains sensitive tokens)
+.codex/
+
 # macOS
 .DS_Store
 

--- a/e2e/mcp.e2e-spec.ts
+++ b/e2e/mcp.e2e-spec.ts
@@ -37,6 +37,8 @@ describe('MCP Proxy (e2e)', () => {
     const cfgSrcPath = path.join(__dirname, '..', 'config.json');
     const cfg = JSON.parse(fs.readFileSync(cfgSrcPath, 'utf-8'));
     cfg.mcpProxy.addr = ':0';
+    // Use streamable-http for these tests
+    cfg.mcpProxy.type = 'streamable-http';
     // Restrict to only required MCP servers to avoid noisy externals
     const originalServers = (cfg.mcpServers ?? {}) as Record<string, any>;
     const mcpServers: Record<string, any> = {};
@@ -108,14 +110,18 @@ describe('MCP Proxy (e2e)', () => {
   };
 
   it('github client blocks specified tools', async () => {
-    const names = await connectAndListTools('github');
+    const names = await connectAndListTools(
+      'github'
+    );
     expect(names.length).toBeGreaterThan(0);
     expect(names).not.toContain('create_repository');
     expect(names).not.toContain('create_or_update_file');
   }, 60000);
 
   it('github-allow client only exposes allow-listed tools', async () => {
-    const names = await connectAndListTools('github-allow');
+    const names = await connectAndListTools(
+      'github-allow'
+    );
     expect(names).toEqual([ 'list_issues', 'search_repositories' ]);
   }, 60000);
 

--- a/e2e/mcp.search-repositories.e2e-spec.ts
+++ b/e2e/mcp.search-repositories.e2e-spec.ts
@@ -32,6 +32,7 @@ describe('MCP Proxy search_repositories (e2e)', () => {
     const cfgSrcPath = path.join(__dirname, '..', 'config.json');
     const cfg = JSON.parse(fs.readFileSync(cfgSrcPath, 'utf-8'));
     cfg.mcpProxy.addr = ':0';
+    cfg.mcpProxy.type = 'streamable-http'; // Use streamable-http for these tests
 
     const originalServers = (cfg.mcpServers ?? {}) as Record<string, any>;
     const mcpServers: Record<string, any> = {};


### PR DESCRIPTION
## Problem
Codex CLI integration was failing with a ~30 second timeout during MCP handshake due to slow downstream client initialization. Additionally, stdout contamination from logging was corrupting the JSON-RPC stream.

## Solution
- **Lazy initialization**: Return empty tool list during initial handshake, then initialize downstream clients in the background
- **Clean stdio mode**: Redirect all logging to stderr when running in stdio mode to keep stdout clean for JSON-RPC
- **Background init**: Trigger downstream client initialization after the MCP handshake completes
- **Process lifecycle**: Keep stdio process alive indefinitely after connection

## Changes
- Modified `mcp-client-wrapper.ts` to support lazy initialization with `ensureInitialized()` pattern
- Updated `main.ts` to detect stdio mode and redirect console logging to stderr
- Enhanced `mcp-server.service.ts` to handle background initialization
- Improved config handling for stdio target mode
- Added local dogfood configuration for testing
- Updated `.gitignore` to exclude `.codex/` folder

## Testing
- Verified Codex CLI can successfully connect and list tools
- Confirmed downstream clients initialize correctly in background
- Tested that tools become available after initialization completes

## Compatibility
- Backward compatible with existing HTTP/SSE modes
- Only applies lazy initialization in stdio mode
- No breaking changes to API or configuration format