### PR TITLE
chore: update GitHub Actions workflow to use GITHUB_TOKEN for authent…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run e2e tests with coverage
         if: matrix.suite == 'e2e'
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_E2E_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run test:e2e:cov
 
       - name: Upload ${{ matrix.suite }} test results
@@ -153,12 +153,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 Configure npm for dual registry publishing
-        env:
-          PUBLIC_RELEASE_BOT_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
         run: |
           # GitHub Packages npmrc (for first publish)
           echo "@growthspace-engineering:registry=https://npm.pkg.github.com" > .npmrc.gh
-          echo "//npm.pkg.github.com/:_authToken=${PUBLIC_RELEASE_BOT_TOKEN}" >> .npmrc.gh
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc.gh
           
           # For npmjs provenance publish, we need the default npm config
           # to allow OIDC authentication. Configure scope in default .npmrc
@@ -168,9 +166,9 @@ jobs:
       - name: 🚀 Semantic Release
         id: semrel
         uses: cycjimmy/semantic-release-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}
-          # NPM_TOKEN not needed - using provenance (OIDC) for npmjs publishing
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        # NPM_TOKEN not needed - using provenance (OIDC) for npmjs publishing
 
       # decide the channel tag (beta vs latest)
       - name: 🔧 Decide Docker channel tag
@@ -222,7 +220,7 @@ jobs:
           echo "Triggering update-beta-after-release workflow for tag: $NEW_TAG"
 
           curl -X POST \
-            -H "Authorization: token ${{ secrets.PUBLIC_RELEASE_BOT_TOKEN }}" \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/dispatches \
             -d "{\"event_type\":\"release_created\",\"client_payload\":{\"tag_name\":\"$NEW_TAG\"}}"


### PR DESCRIPTION
…ication

Replaced PUBLIC_E2E_GITHUB_TOKEN and PUBLIC_RELEASE_BOT_TOKEN with GITHUB_TOKEN in the release workflow for consistency and security. This change ensures that the workflow uses the appropriate token for GitHub actions and npm registry publishing.

## Description
<!-- Brief description of changes -->

## Related Issues
<!-- Link related issues using keywords like "Closes #", "Fixes #", "Resolves #" -->

## Checklist
- Code follows project style guidelines
- Self-review completed
- Documentation updated if needed
- No new warnings generated
- Tests pass locally (`npm test`)
- E2E tests pass if applicable (`npm run test:e2e`)
